### PR TITLE
Switch depth maps to MiDaS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,10 @@
 # ImageEdit
 
 This project provides a minimal command line interface for experimenting with
-image effects using OpenCV and PyQt6. Depth maps are generated from image
-luminance and can be used to drive simple transformations.
+image effects using OpenCV and PyQt6. Depth maps are generated using the
+[MiDaS](https://github.com/isl-org/MiDaS) model which produces more accurate
+results than the previous luminance based placeholder. If the loader cannot
+download the model it falls back to a local copy located in ``models/midas``.
 
 ## Running
 


### PR DESCRIPTION
## Summary
- load local MiDaS model for depth estimation
- compute depth maps using MiDaS instead of image luminance
- fallback to a local repo if the model download fails
- update README for offline fallback

## Testing
- `python -m py_compile app_gui.py app_terminal.py features/effects.py`


------
https://chatgpt.com/codex/tasks/task_e_6877ac4e250883308ba491a26cd37528