### PR TITLE
Enable fully offline MiDaS loading

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,10 +3,18 @@
 This project provides a minimal command line interface for experimenting with
 image effects using OpenCV and PyQt6. Depth maps are generated using the
 [MiDaS](https://github.com/isl-org/MiDaS) model which produces more accurate
-results than the previous luminance based placeholder. If the loader cannot
-download the model it falls back to a local copy located in ``models/midas``.
-Clone the MiDaS repository into this folder if you want offline support.
 results than the previous luminance based placeholder.
+The loader now only uses a local clone located in ``models/midas`` and never
+attempts to download from the internet.  Provide the pretrained weights via
+``weights_path`` if they are already cached, for example:
+
+```
+load_midas_model(
+    model_type="DPT_Large",
+    local_dir="models/midas",
+    weights_path="~/.cache/torch/hub/checkpoints/dpt_large_384.pt",
+)
+```
 
 ## Running
 


### PR DESCRIPTION
## Summary
- allow passing a weight path to `load_midas_model`
- remove online download attempts and always load from a local repo
- document offline usage and how to specify weights

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6877bed8438c83308c8b81e42342d9e0